### PR TITLE
In the Auto-Refresh mode ignore the refresh if the text contains the previous response from LLM

### DIFF
--- a/ClipAI.py
+++ b/ClipAI.py
@@ -143,6 +143,9 @@ class ClipboardViewer:
         # Initialize with current clipboard content
         self.update_clipboard_content()
 
+        # Add a class variable to store the LLM response
+        self.llm_response = ""
+
     def fetch_models(self):
         """Fetch available models from Ollama API"""
         try:
@@ -202,7 +205,7 @@ class ClipboardViewer:
         while self.auto_refresh:
             current_content = pyperclip.paste()
 
-            if current_content != last_content:
+            if current_content != last_content and self.llm_response not in current_content:
                 last_content = current_content
                 # Schedule update on the main thread
                 self.root.after(0, self.update_clipboard_content)
@@ -236,6 +239,8 @@ class ClipboardViewer:
                 self.text_box.insert(tk.END, f"\n\nLLM Response:\n{result}")
                 self.text_box.configure(state="disabled")
                 self.status_var.set(f"Response received from {model}")
+                # Store the LLM response in the class variable
+                self.llm_response = result
             else:
                 self.status_var.set(f"Error {response.status_code}: LLM request failed for {model}")
         except Exception as e:

--- a/ClipAI.py
+++ b/ClipAI.py
@@ -144,7 +144,7 @@ class ClipboardViewer:
         self.update_clipboard_content()
 
         # Add a class variable to store the LLM response
-        self.llm_response = ""
+        self.llm_response = "Chronometer2849"
 
     def fetch_models(self):
         """Fetch available models from Ollama API"""


### PR DESCRIPTION
Add logic to ignore refresh if the text contains the previous response from the LLM in Auto-Refresh mode.

* Add a class variable `self.llm_response` to store the LLM response.
* Update the `send_to_llm` method to store the LLM response in `self.llm_response`.
* Update the `monitor_clipboard` method to check if the current clipboard content contains `self.llm_response` and ignore refresh if they match.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/markod0925/ClipAI/pull/6?shareId=1d0d40c9-66ca-457b-adec-dd542f550201).